### PR TITLE
Use Async HTTP client backed by thread pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Each of these classes can be configured to fit you need and your Akamai credenti
 	accessToken="your_accessToken"
 	defaultPurgeAction="remove"
 	defaultPurgeDomain="production"
-	threadPoolSize="10"/>
+	threadPoolSize="5"/>
 ```
 For more info on credentials see https://developer.akamai.com/introduction/Prov_Creds.html
 
@@ -64,7 +64,7 @@ defaultPurgeDomain : The default domain if not specified.
     - production: (default)
     - staging:
     
-threadPoolSize : Number of threads to dedicate to the API HTTP Client. Defaults to 10.
+threadPoolSize : Number of threads to dedicate to the API HTTP Client. Defaults to 5.
 
 - AkamaiEventHandler: *com.velir.aem.akamai.ccu.impl.AkamaiEventHandler.xml*
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Each of these classes can be configured to fit you need and your Akamai credenti
 	clientSecret="your_clientSecret"
 	accessToken="your_accessToken"
 	defaultPurgeAction="remove"
-	defaultPurgeDomain="production"/>
+	defaultPurgeDomain="production"
+	threadPoolSize="10"/>
 ```
 For more info on credentials see https://developer.akamai.com/introduction/Prov_Creds.html
 
@@ -62,6 +63,8 @@ defaultPurgeAction : The default purge if not specified.
 defaultPurgeDomain : The default domain if not specified.
     - production: (default)
     - staging:
+    
+threadPoolSize : Number of threads to dedicate to the API HTTP Client. Defaults to 10.
 
 - AkamaiEventHandler: *com.velir.aem.akamai.ccu.impl.AkamaiEventHandler.xml*
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.build.jdk>1.6</project.build.jdk>
+		<project.build.jdk>1.8</project.build.jdk>
 		<slf4j.version>1.6.4</slf4j.version>
 		<groovy.version>2.4.7</groovy.version>
 	</properties>

--- a/src/main/groovy/com/velir/aem/akamai/ccu/impl/CcuManagerImpl.groovy
+++ b/src/main/groovy/com/velir/aem/akamai/ccu/impl/CcuManagerImpl.groovy
@@ -29,7 +29,7 @@ import static org.apache.sling.commons.osgi.PropertiesUtil.toString
 	@Property(name = "clientToken", description = "", label = "Client Token"),
 	@Property(name = "clientSecret", description = "", label = "Client Secret", passwordValue = ""),
 	@Property(name= "accessToken", description = "", label="Access Token"),
-	@Property(name = "threadPoolSize", description= "Number of threads for concurrent HTTP connections", longValue = 10l)
+	@Property(name = "threadPoolSize", description= "Number of threads for concurrent HTTP connections", longValue = 5l)
 ])
 class CcuManagerImpl implements CcuManager {
 	private static final Logger LOG = LoggerFactory.getLogger(CcuManagerImpl)
@@ -40,7 +40,7 @@ class CcuManagerImpl implements CcuManager {
 	static final String QUEUES_PATH = "/ccu/v2/queues/default"
 	static final String UTF_8 = "UTF-8"
 	private static final Closure VAL_NOT_NULL = { key, value -> value }
-	private static final int DEFAULT_POOL_SIZE = 10
+	private static final int DEFAULT_POOL_SIZE = 5
 
 	@Property(name = "rootCcuUrl", label = "Akamai CCU API URL", value = "https://api.ccu.akamai.com")
 	private String rootCcuUrl

--- a/src/test/groovy/com/velir/aem/akamai/ccu/impl/CcuManagerImplTest.groovy
+++ b/src/test/groovy/com/velir/aem/akamai/ccu/impl/CcuManagerImplTest.groovy
@@ -7,6 +7,8 @@ import com.velir.aem.akamai.ccu.PurgeType
 import org.osgi.service.component.ComponentContext
 import spock.lang.Specification
 
+import java.util.concurrent.ExecutionException
+
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import static org.apache.http.HttpStatus.SC_CREATED
 /**
@@ -140,7 +142,7 @@ class CcuManagerImplTest extends Specification {
 		ccuManager.purgeByUrls(["http://error-403"])
 
 		then:
-		thrown(RuntimeException)
+		thrown(ExecutionException)
 	}
 
 	def cleanupSpec() {


### PR DESCRIPTION
Issue #7: Use the AsyncHTTPBuilder to fix a concurrency issue when there is a high load of concurrent invalidation requests.

Added OSGi property threadPoolSize which defaults to 10 if it is not provided.